### PR TITLE
Heroku DB 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -102,6 +102,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_BLACK_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
기존에 사용하려던 clearDB 가 MySQL8.0 을 지원하지 않기 때문에 현재 작성된 application DB 자료형이 맞지 않아 에러를 발생시킴에 따라, MySQL8.0 을 지원하는 JawsDB 로 변경

This closes #49