### PR TITLE
[고도화] Refactoring : Entity code - equals(), hashcode() 에서 field 접근을 getter 로 바꾸기

### DIFF
--- a/document/Proxy_객체_접근의_getter_사용.md
+++ b/document/Proxy_객체_접근의_getter_사용.md
@@ -1,0 +1,56 @@
+해당 문서는 Spring 에서 DB 에 접근 및 data 영속성을 부여하는 과정에서 사용되는 Spring 의 각 용어의 개념을 다시 정리해보고, 제목에 명시된 Proxy 객체에 직접 접근할 때 발생 가능한 문제와 이에 대한 해결 방안을 정리한다. 
+
+## 1. 용어 개념 정리
+
+### JPA (Java Persistence API)
+* Java application 에서 관계형 DB 를 사용하여 Data 를 유지 관리 작업에 필요한 API specification.
+* JPA 의 spec. 을 구현하여 Spring application 내에서 Data 접근을 추가항화 하고, Data 저장소화의 상호작용을 단순화 할 수 있도록 해준다.
+
+### Hibernate
+* JPA 의 구현체
+* Java application 과 DB 사이에 ORM(Object-Relational Mapping) 을 실제적으로 제공한다.
+
+### Entity
+* DB table 과 1:1 로 mapping 되는 Java Class
+
+#### => Entity 와 JPA 의 구현체인 Hibernate 를 사용함에 따라, SQL 과 DB migration 작업 없이도 순수 Java application 내애서 DB CRUD 작업이 가능하게 만들어줌. 
+
+## 2. Proxy 객체 및 이에 대한 접근
+
+### Proxy 객체와 Lazy Loading
+* Hibernate 는 성능 최적화를 위해 proxy 객체를 사용하여 Lazy Loading 을 구현한다.
+* 아래 예제와 같이, 만약 User Entity 가 Order Entity 와 연관 관계가 있다면,
+
+```java
+@Entity
+public class User {
+    @Id
+    private Long id;
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<Order> orders;
+
+    public Long getId() {
+        return id;
+    }
+
+    public List<Order> getOrders() {
+        return orders;
+    }
+}
+```
+* User entity 작업 요청이 있을 때마다, Data 가 큰 orders list 를 모두 매번 가져오는 것은 비효율 적일 수 있다.
+* 따라서 Hibernate 는 Orders field 를 바로 load 하지 않고, orders field 참조 객체만 생성한다.
+* 해당 reference 객체가 proxy 객체이며, 이렇게 proxy 객체만 가지고 있다가 실제 data 가 필요할 때, 가져오는 것이 lazy loading 이다.
+
+## 3. Proxy 객체에 직접 접근의 문제 
+* 위 예제에서 만약 아래와 같이 User Entity 를 생성하고 orders Field 에 직접 접근하고자 한다면, Hibernate가 proxy 객체만 생성해 놓은 field 에 직접 접근을 시도했기 때문에, 해당 field 는 초기화 되지 않고 null 이거나 예기치 않은 동작을 일으 킬 수 있다. 
+```java
+        User user = entityManager.find(User.class, userId);
+
+        List<Order> orders = user.orders;  // 이런 방식은 좋지 않습니다.
+```
+* 이 문제를 해결하기 위해 getter method 를 사용해야 한다. 
+```java
+        List<Order> orders = user.getOrders();  // 이것이 올바른 방식입니다.
+```
+* getter method 를 사용하면 Hibernate 는 proxy 객체를 올바르게 처리하고 필요한 시점에 실제 'Order' 객체를 DB 로부터 load 하게 된다. 

--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -81,12 +81,12 @@ public class Article extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Article article = (Article) o;
-        return Objects.equals(id, article.id);
+        return Objects.equals(this.getId(), article.getId()); // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId()); // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 }
 

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -58,11 +58,11 @@ public class ArticleComment extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ArticleComment that = (ArticleComment) o;
-        return Objects.equals(id, that.id);
+        return Objects.equals(this.getId(), that.getId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(getId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -44,11 +44,11 @@ public class UserAccount extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserAccount that = (UserAccount) o;
-        return Objects.equals(userId, that.userId);
+        return Objects.equals(this.getUserId(), that.getUserId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 }


### PR DESCRIPTION
Proxy_객체_접근의_getter_사용.md
 - Spring application 을 이용하여 data 영속성 부여 및 CRUD 작업을 DB Query 및 설정 작업 없이 사용가능하도록 지원해주는 JPA 와 해당 구현체인 Hibernate, DB table mapping 을 위한 Entity 등에 대한 정의를 정리함.
 - 연관관계 Entity 에 대한 Hibernate 의 Lazy Loading 발생 상황 명시
 -  Lazy Loading 을 위한 Proxy 객체 생성과 Proxy 객체에 직접 접근하고자 할때 발생하는 문제와 이에 대한 해결 방안 명시

Article / ArticleComment / UserAccount
 - proxy 객체 접근 시 값이 null 이거나 error 가 발생할 수 있으므로 기존 내부적으로  field 값에 직접 접근하고 있는 equals(), hashcode() method 구현 부분을 모두 getter 를 사용하여 접근하도록 변경함.
 - 그런데 해당 method 에서 사용하고 있는 field 들은  id 로 다른 Entity 를 field 로 가진 부분이 아니며, 자체 value 를 가진 부분인데, 이게 정말 해당문제와 연관이 있는지 모르겠어서 Q&A 를 남김. 
 - https://fastcampus.co.kr/qna/211368/read/16295

This closes #73 