### PR TITLE
#94 - Heruku 배포 오류 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -83,8 +83,8 @@ spring:
       client:
         registration: # oauth provider infomation
           kakao:
-#            client-id: ${KAKAO_OAUTH_CLIENT_ID}         # spirng boot 외부 환경 변수 주입으로 해당 값 입력을 처리하면,
-#            client-secret: ${KAKAO_OAUTH_CLIENT_SECRET} # app 실행 시, spring boot 이  해당 setting 값을 넣고 실행하기 때문에 해당 설정을 삭제해도 동일하게 실행됨.
+            client-id: ${KAKAO_OAUTH_CLIENT_ID}         # spirng boot 외부 환경 변수 주입으로 해당 값 입력을 처리하면,
+            client-secret: ${KAKAO_OAUTH_CLIENT_SECRET} # app 실행 시, spring boot 이  해당 setting 값을 넣고 실행하기 때문에 해당 설정을 삭제해도 동일하게 실행됨.(생략 가능은 local 배포인 경우만)
             authorization-grant-type: authorization_code
 
             # redirect-uri: http://localhost:8080/login/oauth2/code/kakao


### PR DESCRIPTION
이전 내용에서 민감 정보를 외부 주입으로 돌리는 과정에서 application.yaml 에서 Kakao registration 정보 설정 일부를 삭제 하였다. Local 에서는 spring boot 기능으로 외부 변수 주입 기능을 넣어 주었지만, cloud 에서 배포 할 때는 해당 설정이 필요하다. 이를 되돌리는 작업을 진행함.