### PR TITLE
[고도화] 보안 기능 고도화 - Vault + Spring Boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ repositories {
     mavenCentral()
 }
 
+// Heroku 에서 vault 를 사용하지 않기 때문에 해당 설정은 주석 처리하여 비활성화 함
+//ext {
+//    set('springCloudVersion', "2021.0.8") // vault config version 관리를 위한 별도 cloud ??
+//}
+
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -30,6 +36,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'  // 해당 spring security 의존성을 삽입할 때는  Spring web 과 thymelaef 를 반드시 같이 넣고 생성해야
+// Heroku 에서 vault 를 사용하지 않기 때문에 해당 설정은 주석 처리하여 비활성화 함
+//    implementation 'org.springframework.cloud:spring-cloud-starter-vault-config' // vault
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'  // 위 조건일 때 해당 thymeleaf security 의존성 list 가 생성되어 이를 같이 십입 할 수 있음
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -45,10 +53,23 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa" // 해당 library 와 같이 일반적인  경우 ...jpa:version 정보 가 입력되게 되는데
     implementation "com.querydsl:querydsl-core" //  id 'io.spring.dependency-management' version '1.0.15.RELEASE' 가 알아서 해당 위치에 적용 버젼을 넣어준다
     implementation "com.querydsl:querydsl-collections"
+
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // 해당 경우는 버전 위치가 특수하여 수동으로 찾아 넣어주는 gradle 문을 사용함
+// Heroku 에서 vault 를 사용하지 않기 때문에 해당 설정은 주석 처리하여 비활성화 함
+//  위  querydsl dependencyManagement 부분이 VaultConfig 의존성 부분과 충돌이 남 (아마 이것도 아래에 별도 dependencyManagement 있어서 인가?)
+//  따라서 해당 의존성은 version 을 수기로 넣는 것으로 변경
+//    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jpa"
+
     annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응 코드
     annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응 코드
 }
+
+// Heroku 에서 vault 를 사용하지 않기 때문에 해당 설정은 주석 처리하여 비활성화 함
+//dependencyManagement {
+//    imports {
+//        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}" // for Vault Config
+//    }
+//}
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,16 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 spring:
+  # 아래 vault 설정을 사용한 key value pair 로 아래 datasouce 의 url, username, password 를 환경변수로 저장하지않고,
+  # 보안기능이 강화된 vault cloud 기능을 사용하여 작업을 진행 할 수 있다.
+  # 그러나 현재 Heroku 에서 vault 를 사용하지 않기 때문에 해당 설정은 주석 처리하여 비활성화 함
+#  application.name: fastcampus-board # vault 사용하여 생성한 secret/fastcampus-board key-value pair 저장소 이름
+#  cloud.vault:
+#      scheme: http
+#      authentication: TOKEN
+#      token: ${VAULT_TOKEN}   # Root Token: hvs.8fCdxxxEXSoFzL7ij19xxxxx  과 같이 vault server 생성 token 사용
+#  config.import: vault://     # https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/
+
   datasource:
     url: ${LOCAL_DB_URL}
     username: ${LOCAL_DB_USERNAME}


### PR DESCRIPTION
local valut server 를 구동하여 민감정보를 여기에서 저장하므로써 보안 수준을 높이는 작업을 해보았으나,  현재 web service 로 사용하는 Heroku 에 해당 기능 연동을 구현하지 않으므로써 (사용 가능 함.) 해당 작업 내용은 모두 주석 처리하고, 기존 내용을 그대로 복구시켜 놓음.

build.gradle
- vault configuration 에 대한 의존성을 추가하는 과정에 다음의 특징점이 발생함
-  해당 라이브러리 의존성 추가에서 의존성 관리를 하는데 spring cloud 가 필요하며, 이에 대한 dependencyManage 관리 코드가 추가된다.
- 정확한 이유는 모르지만 (아마 별도 dependencyManagement 코드 추가 때문?) 기존에 작성했던 Querydsl version 관리 코드 (자동 입력이 되지 않아 gradle 코드가 추가됨) 와 충돌이 발생. 따라서 해당 부분은 수기로 버전 값을 직접 넣는 것으로 변경해줌.

application.yaml
- vault server -dev 로 개발 환경 vault server 를 구축해 놓은 상태에서 해당 서버에 secret key-value 로 민감정보(datasource.url / username / password)를 넣어 놓는다.
- spring.application.name: kv 저장 공간명칭 (fastcampus-board)
- spring.clould.vault 내 세부 setting 을 설정한다.
- spring.config.import:  vault://   으로 spring 공식 문서 내용대로 입력

This closes #64 