### PR TITLE
main spring boot test 발생 error 해결

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -142,3 +142,12 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
+
+---
+
+  # @SpringBootTest 진행 시, 해당 파일 설정 중 민감정보 외부 환경 변수로 처리한 부분에서 에러가 발생하기 때문에
+  # test 진행시 관련되 부분만 다르게 설정하여 실행할 수 있도록 test 설정을 추가함.
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb
+

--- a/src/test/java/com/fastcampus/projectboard/FastCampusProjectBoardApplicationTests.java
+++ b/src/test/java/com/fastcampus/projectboard/FastCampusProjectBoardApplicationTests.java
@@ -2,7 +2,14 @@ package com.fastcampus.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+// Atice
+// SprigBootTest 로 진행 시,SpringBoot 의 모든 설정과 bean 생성을 실행한다.
+// 그런데 현재 application.yaml 파일에 민감정보를 명시하지 않고 환경 변수에서 가저오도록 설정함으로써,
+// test 과정 error 가 발생하게 된다.
+// 따라서, application.yaml 에서 test 용 설정을 명시하고 실행 profile 을 "test" 로 진행할 수 있도록 annotation 을 붙임
+@ActiveProfiles("test")
 @SpringBootTest
 class FastCampusProjectBoardApplicationTests {
 


### PR DESCRIPTION
spring boot test 의 경우, application.yaml 설정을 그대로 가져와서 실행되는데, 이때 민감정보를 환경변수로 처리한 부분이 test 에서는 작동하지 않기 때문에 에러가 발생한다. 따라서 test 에서 별도 설정을 추가하고, 해당 profile 로 실행할 수 있도록 해당 test에 annotation 을 추가함.

This fixes #98 