### PR TITLE
[고도화] Swagger UI 로 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,14 @@ repositories {
 
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12' // Swagger UI 사용 의존성 주입 : https://springdoc.org/#getting-started
+                                                               // 다만 최신 버전 적용시 complie error 가 발생하여 강의 버전을 적용함.
+//    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12' // swagger UI 에서 spring MVC 자체 REST 처리된 사항을 볼수 있게 해줌
+    implementation 'org.springdoc:springdoc-openapi-javadoc:1.6.12' // swagger ui 에서 입출력 데이터에 대한 설명을 추가하기 위해서 해당 DTO 각 요소에 @Schema annotation 과 같은 것을 모두 붙여야 함.
+                                                                    // java code 내 swagger 많을 위한 annotation 을 사용하고 싶지 않다면 해당 의존성을 필요로 함.
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0' // class 에서 명시한 java doc 주석을 swagger UI 에서 표시해줌
+                                                                    // https://springdoc.org/#javadoc-support
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/fastcampus/projectboard/controller/MainController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/MainController.java
@@ -1,8 +1,18 @@
 package com.fastcampus.projectboard.controller;
 
+import com.fastcampus.projectboard.dto.response.ArticleCommentResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.time.LocalDateTime;
+
+/**
+ * <p>
+ * 메인 컨트롤러
+ * <p>
+ * 테스트 중
+ * */
 @Controller
 public class MainController {
 
@@ -10,5 +20,26 @@ public class MainController {
     public String root() {
         return "forward:/articles";
     }
+
+    // Swagger UI 실행 관련 확인용 controller 실행??
+    /**
+     *  댓글 정보를 열람한다.
+     *
+     * @param id 댓글 ID
+     * @return 댓글 응답
+     * */
+    @ResponseBody
+    @GetMapping("/test-rest")
+    public ArticleCommentResponse test(Long id) {
+        return ArticleCommentResponse.of(
+                id,
+                "content",
+                LocalDateTime.now(),
+                "e@mail.com",
+                "nickname",
+                "gon"
+        );
+    }
+
 }
 

--- a/src/main/java/com/fastcampus/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/response/ArticleCommentResponse.java
@@ -9,6 +9,7 @@ import java.util.TreeSet;
 
 /**
  * DTO for {@link com.fastcampus.projectboard.domain.ArticleComment}
+ * Swagger UI 에서 확인 필요
  */
 public record ArticleCommentResponse(
         Long id,


### PR DESCRIPTION
http://localhost:8080/swagger-ui.html

build.gradle
 - springdoc-openapi-ui   : https://springdoc.org/#getting-started 에 명시된 최신 버전 적용시 에러가 발생하여, 강의에서 사용하는 동일 버전을 적용함. 아래 추가 의존성 주입도 동일하게 강의 기준 버전을 적용
 - springdoc-openapi-javadoc / therapi:therapi-runtime-javadoc-scribe
: swager UI 에서 입출력 받는 data 에 대한 설명을 추가하기 위해 DTO element 에 annotation 을 붙이는 방법이 일반적으로 있으나,  순수 java code 영역에 외부 code  적용이 호불호의 영역이므로, 이를 이를 대체하기 위해 해당 의존성을 추가하고, 각 class / method 에 java doc 을 작성하면, 이를 Swagger UI 에서 보여지도록 사용할 수 있음.

MainController
 - Swagger UI 에서 REST 입/출력 data 를 확인하기 위한 test method 및 java doc 추가

ArticleCommentResponse
-  java doc 추가

This closes #65 