### PR TITLE
테스트용 계정 추가

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,6 +6,9 @@ insert into user_account (user_id, user_password, nickname, email, memo, created
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
     ('uno2', '{noop}asdf1234', 'Uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
 ;
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+    ('uno3', '{noop}asdf1234', 'Uno3', 'uno3@mail.com', 'I am Uno3.', now(), 'uno3', now(), 'uno3')
+;
 
 -- 123 게시글
 insert into article (user_id, title, content, created_by, modified_by, created_at, modified_at) values


### PR DESCRIPTION
관리자 프로젝트에서 일반 회원 정보 관리 (삭제) 할 때, 구현 여부 확인을 확인하기 위해, 게시글과 댓글 작성 이력이 없는 계정이 필요하다. 이를 위한 계정을 추가한다.

This closes #105 